### PR TITLE
Don't fail silently if tests fail

### DIFF
--- a/lib/tasks/protractor.rake
+++ b/lib/tasks/protractor.rake
@@ -28,7 +28,7 @@ namespace :protractor do
       puts "Rails Server PID: #{rails_server_pid}".yellow.bold
       puts "Waiting for servers to finish starting up...."
       sleep 6
-      system 'protractor spec/javascripts/protractor.conf.js'
+      success = system 'protractor spec/javascripts/protractor.conf.js'
       Process.kill 'TERM', webdriver_pid
       Process.kill 'TERM', rails_server_pid
       Process.wait webdriver_pid
@@ -39,6 +39,7 @@ namespace :protractor do
       puts e
     ensure
       Rake::Task["protractor:kill"].invoke
+      exit success
     end
   end
 


### PR DESCRIPTION
Currently, `protractor:spec` returns with exit code 0 whether the protractor tests pass or not.

This can cause issues when using continuous integration, as the CI assumes that the rake task has completed successfully, and will move on to further steps in the process (such as migrations, deployments, etc.)

This passes the exit code of the protractor system call out through the rake task, so that exit code will be 1 if the tests fail.
