### PR TITLE
only exit spec rake task if protractor command cannot complete ok

### DIFF
--- a/lib/tasks/protractor.rake
+++ b/lib/tasks/protractor.rake
@@ -52,6 +52,7 @@ namespace :protractor do |args|
       write_log "Waiting for servers to finish starting up...."
       sleep Protractor.configuration.startup_timeout
       success = system "protractor #{options} #{Protractor.configuration.config_path}/#{Protractor.configuration.config_file}"
+      write_log "Protractor has failed to run test with options '#{options}'".red.bold unless success
       Process.kill 'TERM', webdriver_pid
       Process.kill 'TERM', rails_server_pid
       Process.wait webdriver_pid
@@ -62,7 +63,7 @@ namespace :protractor do |args|
       puts e
     ensure
       Rake::Task["protractor:kill"].invoke
-      exit success
+      exit unless success
     end
   end
 


### PR DESCRIPTION
This should fix [issue #19](https://github.com/tyronewilson/protractor-rails/issues/19). While running `spec_and_cleanup` task, `spec` task is always firing system exit, preventing the `cleanup` task to actually run.
The fix is to avoid exiting unless spec tests are failing to run.  