### PR TITLE
Allow rails server env to be specified

### DIFF
--- a/lib/tasks/protractor.rake
+++ b/lib/tasks/protractor.rake
@@ -93,7 +93,8 @@ namespace :protractor do |args|
 
   task :rails do
     write_log "Starting Rails server on port #{Protractor.configuration.port} pid file in tmp/pids/protractor_test_server.pid".green
-    rails_command = "rails s -e test -P tmp/pids/protractor_test_server.pid --port=#{Protractor.configuration.port}"
+    env = ENV['PROTRACTOR_ENV'] ||= 'test'
+    rails_command = "rails s -e #{env} -P tmp/pids/protractor_test_server.pid --port=#{Protractor.configuration.port}"
     if ENV['rails_binding'] != nil
       rails_command << " --binding #{ ENV['rails_binding'] }"
     end

--- a/lib/tasks/protractor.rake
+++ b/lib/tasks/protractor.rake
@@ -92,8 +92,8 @@ namespace :protractor do |args|
   end
 
   task :rails do
-    write_log "Starting Rails server on port #{Protractor.configuration.port} pid file in tmp/pids/protractor_test_server.pid".green
-    env = ENV['PROTRACTOR_ENV'] ||= 'test'
+    env = ENV['PROTRACTOR_SERVER_ENV'] ||= 'test'
+    write_log "Starting Rails server on port #{Protractor.configuration.port} environement #{env} pid file in tmp/pids/protractor_test_server.pid".green
     rails_command = "rails s -e #{env} -P tmp/pids/protractor_test_server.pid --port=#{Protractor.configuration.port}"
     if ENV['rails_binding'] != nil
       rails_command << " --binding #{ ENV['rails_binding'] }"

--- a/lib/tasks/protractor.rake
+++ b/lib/tasks/protractor.rake
@@ -88,7 +88,7 @@ namespace :protractor do |args|
 
   task :kill_rails do
     write_log "kill protractor rails tests server...".yellow
-    system "ps aux | grep -ie 'rails s -e test -P tmp/pids/protractor_test_server.pid --port=#{Protractor.configuration.port}' | grep -v grep | awk '{print $2}' | xargs kill -9"
+    system "kill `cat tmp/pids/protractor_test_server.pid`"
   end
 
   task :rails do


### PR DESCRIPTION
There may be some sever env specific configurations which require using a rails environment other than test. Allow configuration for it via an ENV variable, otherwise use test.