### PR TITLE
Added an alternative ENV-based parameter passing method.

### DIFF
--- a/lib/tasks/protractor.rake
+++ b/lib/tasks/protractor.rake
@@ -39,6 +39,9 @@ namespace :protractor do |args|
         end
       end.parse!
 
+      options += "--specs #{ENV['SPECS']}" if ENV['SPECS'].present?
+      options += "--suite #{ENV['SUITE']}" if ENV['SUITE'].present?
+
       webdriver_pid = fork do
         [$stdout,$stderr].each { |fh| fh.reopen File.open("/dev/null","w") } if ENV['nolog'].present? || ENV['nolog_selenium'].present?
         Rake::Task['protractor:webdriver'].invoke


### PR DESCRIPTION
An alternative way to pass --specs and --suite parameters to protractor from rake.

Old syntax:
```bash
rake protractor:spec -- --specs spec/javascripts/protractor_specs/myfolder/myfile.js
```
New syntax:

```bash
rake protractor:spec SPECS=spec/javascripts/protractor_specs/myfolder/myfile.js
```

It should fix #32 #25 

Tested locally on a rails 4.1.9, ruby 2.2.1 project.