### PR TITLE
Add server option

### DIFF
--- a/lib/protractor/rails/configuration.rb
+++ b/lib/protractor/rails/configuration.rb
@@ -27,6 +27,7 @@ module Protractor
                   :config_file,
                   :startup_timeout,
                   :spec_path,
+                  :server,
                   :port
 
     def initialize ( data=nil )
@@ -35,6 +36,7 @@ module Protractor
       @config_file     = get( :config_file ) || 'protractor.conf.js'
       @spec_path       = get( :spec_path ) || 'spec/javascripts'
       @startup_timeout = get( :startup_timeout ) || 8
+      @server          = get( :server ) || 'webrick'
       @port            = get( :port ) || 4000
     end
 

--- a/lib/tasks/protractor.rake
+++ b/lib/tasks/protractor.rake
@@ -96,8 +96,9 @@ namespace :protractor do |args|
 
   task :rails do
     env = ENV['PROTRACTOR_SERVER_ENV'] ||= 'test'
-    write_log "Starting Rails server on port #{Protractor.configuration.port} environement #{env} pid file in tmp/pids/protractor_test_server.pid".green
-    rails_command = "rails s -e #{env} -P tmp/pids/protractor_test_server.pid --port=#{Protractor.configuration.port}"
+    server = Protractor.configuration.server
+    write_log "Starting Rails server #{server} on port #{Protractor.configuration.port} environement #{env} pid file in tmp/pids/protractor_test_server.pid".green
+    rails_command = "rails s #{server} -e #{env} -P tmp/pids/protractor_test_server.pid --port=#{Protractor.configuration.port}"
     if ENV['rails_binding'] != nil
       rails_command << " --binding #{ ENV['rails_binding'] }"
     end


### PR DESCRIPTION
Make it possible to specify the web server in `config/protractor.yml`

Example:
```yml
server: webrick
```

Why: for some reason Puma does not play well with Protractor on OSX so I had to fall back to Webrick. 